### PR TITLE
Fix/null ref outside app

### DIFF
--- a/src/AobD.WinKeyboardHook.WPF/KeyboardInterceptor.cs
+++ b/src/AobD.WinKeyboardHook.WPF/KeyboardInterceptor.cs
@@ -88,6 +88,11 @@ namespace AobD.WinKeyboardHook.WPF
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern short GetAsyncKeyState(Key key);
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        private static extern int GetWindowThreadProcessId(IntPtr handle, out int pid);
         #endregion
 
         public event EventHandler<KeyEventArgs> KeyDown;
@@ -144,6 +149,21 @@ namespace AobD.WinKeyboardHook.WPF
             return isRepeat;
         }
 
+        private bool ApplicationHasFocus()
+        {
+            IntPtr activatedWindowHandle = GetForegroundWindow();
+
+            if(activatedWindowHandle == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            GetWindowThreadProcessId(activatedWindowHandle, out int pid);
+
+            return pid == Process.GetCurrentProcess().Id;
+
+        }
+
         private IntPtr KeyboardHandler(int nCode, IntPtr wParam, IntPtr lParam)
         {
             if(nCode >= 0)
@@ -151,6 +171,11 @@ namespace AobD.WinKeyboardHook.WPF
                 KBDLLHOOKSTRUCT keyInfo = (KBDLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(KBDLLHOOKSTRUCT));
 
                 var key = KeyInterop.KeyFromVirtualKey(keyInfo.key);
+
+                if(!ApplicationHasFocus())
+                {
+                    return CallNextHookEx(ptrHook, nCode, wParam, lParam);
+                }
 
                 if(DisableRepeat && IsRepeat(keyInfo))
                 {

--- a/src/AobD.WinKeyboardHook.WPF/KeyboardInterceptor.cs
+++ b/src/AobD.WinKeyboardHook.WPF/KeyboardInterceptor.cs
@@ -31,6 +31,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
+using System.Windows.Interop;
 
 namespace AobD.WinKeyboardHook.WPF
 {
@@ -168,7 +169,7 @@ namespace AobD.WinKeyboardHook.WPF
                 }
 
                 var eventArgs = new KeyEventArgs(Keyboard.PrimaryDevice,
-                                                 Keyboard.PrimaryDevice.ActiveSource,
+                                                 Keyboard.PrimaryDevice?.ActiveSource ?? new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero),
                                                  keyInfo.time,
                                                  key);
 


### PR DESCRIPTION
Fixed a bug that caused an exception to be thrown in non-English localization when typing outside of the example program. 